### PR TITLE
Create report-false-kfm-redirection

### DIFF
--- a/report-false-kfm-redirection
+++ b/report-false-kfm-redirection
@@ -1,0 +1,21 @@
+$desktop_false = {}.Invoke()
+$documents_false = {}.Invoke()
+$pictures_false = {}.Invoke()
+Get-ChildItem "path to location of output files" -Filter *.txt |
+ForEach-Object {
+  $filename = $_.FullName
+  Get-Content $_.FullName | ForEach-Object {
+    if ($_ -match "Desktop_is_in_OneDrive" -and $_ -match "False") {
+      $desktop_false.add($filename)
+    }
+    if ($_ -match "Documents_is_in_OneDrive" -and $_ -match "False") {
+      $documents_false.add($filename)
+    }
+    if ($_ -match "Pictures_is_in_OneDrive" -and $_ -match "False") {
+      $pictures_false.add($filename)
+    }
+  }
+}
+Write-Output "Desktop folder not in OD4B:" $desktop_false
+Write-Output "Documents folder not in OD4B:" $documents_false
+Write-Output "Pictures folder not in OD4B:" $pictures_false


### PR DESCRIPTION
This is a script to process all the output files generated by KFM_Deployment.ps1 and report which text files contain false value for the three folder redirection checks.

|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | no                             |
| New feature?    | no                             |
| New script?     | yes                             |
| Related issues? | n/a |

## What's in this Pull Request?

> Please describe the changes in this PR. Sample description or details around bugs which are being fixed.
> 
> A large deployment of KFM might require an organization to obtain status information from many devices. Rather than reviewing the output manually, this script will execute against all the txt files in the specified directory and summarize which ones contains false values for the three folder redirection checks. 


